### PR TITLE
Remove debug banner from Flutter app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ class _MyAppState extends State<MyApp> {
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: themeMode,
+      debugShowCheckedModeBanner: false,
       home: HomePage(
         themechange: themechange,
       ),


### PR DESCRIPTION
This PR removes the debug banner that appears in the top-right corner of the Flutter app by setting debugShowCheckedModeBanner to false in the MaterialApp widget.